### PR TITLE
Updating for 1.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.10-SNAPSHOT'
+	id 'fabric-loom' version '0.11-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-minecraft_version=1.18.1
-yarn_mappings=1.18.1+build.1
-loader_version=0.12.12
+minecraft_version=1.18.2
+yarn_mappings=1.18.2+build.3
+loader_version=0.13.3
 
 # Mod Properties
 mod_version = 1.1.5
@@ -12,4 +12,4 @@ maven_group = com.github.clevernucleus
 archives_base_name = dataattributes
 
 # Dependencies
-fabric_version=0.46.1+1.18
+fabric_version=0.51.1+1.18.2

--- a/src/main/java/com/github/clevernucleus/dataattributes/mixin/SimpleRegistryMixin.java
+++ b/src/main/java/com/github/clevernucleus/dataattributes/mixin/SimpleRegistryMixin.java
@@ -15,7 +15,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.github.clevernucleus.dataattributes.mutable.MutableSimpleRegistry;
-import com.google.common.collect.BiMap;
 import com.mojang.serialization.Lifecycle;
 
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
@@ -38,11 +37,11 @@ abstract class SimpleRegistryMixin<T> implements MutableSimpleRegistry<T> {
 	
 	@Final
 	@Shadow
-	private BiMap<Identifier, T> idToEntry;
+	private Map<Identifier, T> idToEntry;
 	
 	@Final
 	@Shadow
-	private BiMap<RegistryKey<T>, T> keyToEntry;
+	private Map<RegistryKey<T>, T> keyToEntry;
 	
 	@Final
 	@Shadow


### PR DESCRIPTION
I updated the mappings for 1.18.2. The only thing that broke was that two fields in SimpleRegistry changed from BiMaps to Maps. I've built it and tested it on 1.18.2 and it appears to work.